### PR TITLE
Fix TDAI-1120/3400 source names never populating

### DIFF
--- a/lyngdorf/const.py
+++ b/lyngdorf/const.py
@@ -63,6 +63,7 @@ Msg = Enum(
         "SOURCE",
         "SOURCES",  # Source list query
         "SOURCE_LIST",  # TDAI source list query
+        "SOURCE_NAME",  # TDAI current-source-with-name query / list-population key
         "ZONE_B_POWER",
         "ZONE_B_POWER_ON",
         "ZONE_B_POWER_OFF",

--- a/lyngdorf/device.py
+++ b/lyngdorf/device.py
@@ -142,7 +142,14 @@ class Receiver:
 
         # Sources
         self._register_callback(Msg.SOURCES_COUNT, self._sources.count_callback)
-        self._register_callback(Msg.SOURCE, self._source_callback)
+        # TDAI replies to a source query with a bare index (!SRC(n)) and
+        # carries the name under a differently-shaped SRCNAME message
+        # instead - use that one if present, since a bare index alone is
+        # useless for populating names.
+        if self._model.supports_message(Msg.SOURCE_NAME):
+            self._register_callback(Msg.SOURCE_NAME, self._source_name_callback)
+        else:
+            self._register_callback(Msg.SOURCE, self._source_callback)
         self._register_callback(Msg.STREAM_TYPE, self._stream_type_callback)
 
         # Power
@@ -342,6 +349,20 @@ class Receiver:
             self._notify_notification_callbacks()
         else:
             self._sources.add(int(param1), param2)
+
+    def _source_name_callback(self, param1: str, param2: str):
+        """Handle a SRCNAME reply (TDAI): index and name arrive comma-
+        separated inside one set of parens - "!SRCNAME(0,\"HDMI\")" - not
+        split into two fields the way MP's "!SRC(0)\"HDMI\"" is, so this
+        can't reuse _source_callback's parsing.
+        """
+        index_str, _, name = param1.partition(",")
+        name = name.strip('"')
+        if self._sources.is_full():
+            self._source = name
+            self._notify_notification_callbacks()
+        else:
+            self._sources.add(int(index_str), name)
 
     @property
     def available_sources(self) -> list[str]:

--- a/lyngdorf/models/tdai_series.py
+++ b/lyngdorf/models/tdai_series.py
@@ -42,6 +42,12 @@ TDAI_MESSAGES: dict[Msg, str] = {
     Msg.SOURCES_COUNT: "SRCCOUNT",
     Msg.SOURCE: "SRC",
     Msg.SOURCE_LIST: "SRCLIST",
+    # !SRC? replies with a bare index (!SRC(n)), no name. The name-bearing
+    # replies - both the SRCLIST? list-population burst
+    # (!SRCNAME(a,"Name") repeated) and the current-source query
+    # (!SRCNAME(n,"Name")) - are keyed under SRCNAME instead. See
+    # docs/tdai-1120.md.
+    Msg.SOURCE_NAME: "SRCNAME",
     Msg.STREAM_TYPE: "STREAMTYPE",
     Msg.ROOM_PERFECT_POSITIONS_COUNT: "RPCOUNT",
     Msg.ROOM_PERFECT_POSITION: "RP",
@@ -62,7 +68,9 @@ TDAI_SETUP_MESSAGES: list[str] = [
     f"{TDAI_MESSAGES[Msg.SOURCE_LIST]}?",
     f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_POSITION_LIST]}?",
     f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_VOICING_LIST]}?",
-    f"{TDAI_MESSAGES[Msg.SOURCE]}?",
+    # SRCNAME?, not SRC? - the current-source query needs the name, and
+    # !SRC? doesn't carry one (see Msg.SOURCE_NAME above).
+    f"{TDAI_MESSAGES[Msg.SOURCE_NAME]}?",
     f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_POSITION]}?",
     f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_VOICING]}?",
     f"{TDAI_MESSAGES[Msg.STREAM_TYPE]}?",

--- a/tests/basic_wiring_test.py
+++ b/tests/basic_wiring_test.py
@@ -2506,6 +2506,101 @@ class TestTdaiStateEncoding:
 
 
 # =============================================================================
+# TDAI Source Names
+#
+# !SRC? on a TDAI replies with a bare index (!SRC(n)) - no name. The
+# name-bearing replies are keyed under a different message, SRCNAME, and
+# pack index and name comma-separated inside one set of parens -
+# !SRCNAME(a,"Name") - rather than MP's !SRC(a)"Name" (name trailing,
+# outside the parens). Both the SRCLIST? list-population burst and the
+# current-source query use this SRCNAME shape. See docs/tdai-1120.md.
+# =============================================================================
+
+
+class TestTdaiSourceName:
+    """TDAI source names must populate despite the differently-shaped reply."""
+
+    future = None
+
+    def _callback(self, param1, param2):
+        if self.future is not None and not self.future.done():
+            self.future.set_result(True)
+
+    def test_tdai_1120_and_3400_support_source_name(self):
+        """TDAI-1120/3400 have a SOURCE_NAME message mapped."""
+        assert LyngdorfModel.TDAI_1120.supports_message(Msg.SOURCE_NAME) is True
+        assert LyngdorfModel.TDAI_3400.supports_message(Msg.SOURCE_NAME) is True
+
+    def test_tdai_2170_and_others_have_no_source_name(self):
+        """TDAI-2170 has no bulk/no-arg SRCNAME query, only per-index
+        SRCNAME(n)? - out of scope for this fix. MP and P never needed one
+        since their SRC reply already carries a name."""
+        assert LyngdorfModel.TDAI_2170.supports_message(Msg.SOURCE_NAME) is False
+        assert LyngdorfModel.MP_60.supports_message(Msg.SOURCE_NAME) is False
+        assert LyngdorfModel.P_100.supports_message(Msg.SOURCE_NAME) is False
+
+    @pytest.mark.asyncio
+    async def test_tdai_source_list_populates_names(self):
+        """The SRCLIST? burst (SRCCOUNT then repeated SRCNAME(a,"Name"))
+        must populate available_sources with real names, not stay empty."""
+
+        def test_function(client: Receiver):
+            assert client.available_sources == ["HDMI", "Optical"]
+
+        await self._receive(
+            ["!SRCCOUNT(2)", '!SRCNAME(0,"HDMI")', '!SRCNAME(1,"Optical")'],
+            test_function,
+        )
+
+    @pytest.mark.asyncio
+    async def test_tdai_current_source_resolves_after_list_is_full(self):
+        """Once the source list is full, a further SRCNAME reply must be
+        treated as "current source changed", not another list entry -
+        this used to stay None forever because !SRC? carries no name at
+        all to fall back on."""
+
+        def test_function(client: Receiver):
+            assert client.source == "Optical"
+
+        await self._receive(
+            [
+                "!SRCCOUNT(2)",
+                '!SRCNAME(0,"HDMI")',
+                '!SRCNAME(1,"Optical")',
+                '!SRCNAME(1,"Optical")',
+            ],
+            test_function,
+        )
+
+    async def _receive(self, commands_received, test_function):
+        """Feed raw TDAI-shaped messages to a TDAI-1120 receiver."""
+        transport = mock.Mock()
+        protocol = LyngdorfProtocol(None, None)
+
+        def create_conn(proto_lambda, host, port):
+            proto = proto_lambda()
+            protocol._on_connection_lost = proto._on_connection_lost
+            protocol._on_message = proto._on_message
+            return [transport, proto]
+
+        client = await async_create_receiver(FAKE_IP, LyngdorfModel.TDAI_1120)
+
+        with mock.patch("asyncio.get_event_loop", new_callable=mock.Mock) as debug_mock:
+            debug_mock.return_value.create_connection = AsyncMock(
+                side_effect=create_conn
+            )
+            await client.async_connect()
+            self.future = asyncio.Future()
+            client._api.register_callback("BAL", self._callback)
+            protocol.data_received(
+                bytes("\r".join([*commands_received, "!BAL(0)"]) + "\r", "utf-8")
+            )
+            await self.future
+            test_function(client)
+            await client.async_disconnect()
+
+
+# =============================================================================
 # Message Framing
 #
 # Messages end with CR, but the TDAI family sends CR LF. Splitting on CR


### PR DESCRIPTION
## Problem

Flagged by @Pharkie in #17 (thanks for the pointer): `TDAI_MESSAGES` had no `SRCNAME` entry, so TDAI source names never populate - `available_sources`/`source` stay empty/`None` on a TDAI-1120 or TDAI-3400.

## Root cause

`!SRC?` on these models replies with a bare index only (`!SRC(n)`) - no name at all. The name-bearing replies (both the `SRCLIST?` list-population burst and the current-source query) are keyed under a *different* command, `SRCNAME`, and pack index and name comma-separated **inside one set of parens**:

```
!SRCNAME(0,"HDMI")
```

rather than MP's `!SRC(0)"HDMI"` (name trailing, outside the parens). `_source_callback`'s generic index/name parsing assumes the MP shape, so even adding a `Msg` mapping for `SRCNAME` couldn't reuse it as-is - `int(param1)` would throw on the combined `0,"HDMI"` string.

Per `docs/tdai-1120.md`:

| | current-source reply | list-population reply |
|---|---|---|
| MP/P | `!SRC(n)"Name"` | `!SRCCOUNT(N)` + `!SRC(a)"Name"` repeated |
| TDAI-1120/3400 | `!SRCNAME(n,"Name")` | `!SRCCOUNT(N)` + `!SRCNAME(a,"Name")` repeated |

## Fix

- New `Msg.SOURCE_NAME` mapped to `SRCNAME` for TDAI-1120/3400 only.
- New `_source_name_callback` that splits the comma-packed `index,"name"` parameter before falling into the same is-the-list-full? logic `_source_callback` already uses.
- `async_connect()` picks whichever message the model actually supports (`supports_message(Msg.SOURCE_NAME)`) - MP/P take the unchanged code path.
- Setup sequence queries `SRCNAME?` instead of the nameless `SRC?` for the initial current-source fetch on TDAI-1120/3400.

**No public API changes** - `client.source`, `client.available_sources`, and the `client.source = "name"` setter behave identically. Only the internal message wiring that populates them for TDAI-1120/3400 changes.

## Not covered

TDAI-2170 has no bulk or no-arg `SRCNAME` query - only per-index `SRCNAME(n)?`, which would need iterating over the `SRCENABLED` bitmask rather than a single list query. Left as a known gap; TDAI-2170 keeps its pre-existing (also broken) behavior.

## Verification

- 167 tests pass, `black`/`ruff`/`mypy` clean.
- New `TestTdaiSourceName`: list-population from a raw `SRCLIST?`-shaped burst, and current-source resolution once the list is full - both fail without this fix.
- Confirmed against a **real MP-60** that its source resolution is unaffected (unchanged code path, `source`/`available_sources` still resolve correctly).
- **Not yet verified against real TDAI-1120/3400 hardware** - spec-derived from `docs/tdai-1120.md`. @Pharkie, since you have a TDAI-1120, would you be able to test this branch against it?