### PR TITLE
Fix TDAI-2170 sources/RP positions/voicings never populating

### DIFF
--- a/lyngdorf/const.py
+++ b/lyngdorf/const.py
@@ -64,6 +64,7 @@ Msg = Enum(
         "SOURCES",  # Source list query
         "SOURCE_LIST",  # TDAI source list query
         "SOURCE_NAME",  # TDAI current-source-with-name query / list-population key
+        "SOURCES_ENABLED",  # TDAI-2170 bitmask of which fixed sources are enabled
         "ZONE_B_POWER",
         "ZONE_B_POWER_ON",
         "ZONE_B_POWER_OFF",
@@ -88,10 +89,12 @@ Msg = Enum(
         "ROOM_PERFECT_POSITION",
         "ROOM_PERFECT_POSITIONS",  # Room Perfect position list query
         "ROOM_PERFECT_POSITION_LIST",  # TDAI Room Perfect position list query
+        "ROOM_PERFECT_POSITIONS_PRESENT",  # TDAI-2170 bitmask of which fixed positions are present
         "ROOM_PERFECT_VOICINGS_COUNT",
         "ROOM_PERFECT_VOICING",
         "ROOM_PERFECT_VOICINGS",  # Room Perfect voicing list query
         "ROOM_PERFECT_VOICING_LIST",  # TDAI Room Perfect voicing list query
+        "ROOM_PERFECT_VOICINGS_ENABLED",  # TDAI-2170 bitmask of which fixed voicings are enabled
         "LIP_SYNC",
         "LIP_SYNC_MIN_MAX",
         "TRIM_BASS",

--- a/lyngdorf/device.py
+++ b/lyngdorf/device.py
@@ -126,6 +126,22 @@ class Receiver:
             return
         self._api.register_callback(command, callback)
 
+    @staticmethod
+    def _populate_fixed_list(
+        target: CountingNumberDict, fixed_names: dict[int, str], bitmask: str
+    ) -> None:
+        """Populate a dict of fixed, hardware-defined names filtered by a
+        bitmask reply (e.g. TDAI-2170's SRCENABLED/RPSTATUS/VOIENABLED).
+
+        Bit 0 is the least-significant bit, i.e. the rightmost character
+        of the bitmask string, per the vendor manual.
+        """
+        enabled_indices = [i for i, bit in enumerate(reversed(bitmask)) if bit == "1"]
+        target.count_callback(str(len(enabled_indices)), "")
+        for index in enabled_indices:
+            if index in fixed_names:
+                target.add(index, fixed_names[index])
+
     async def async_connect(self):
         # Basics
         self._register_callback(Msg.DEVICE, self._name_callback)
@@ -142,12 +158,16 @@ class Receiver:
 
         # Sources
         self._register_callback(Msg.SOURCES_COUNT, self._sources.count_callback)
-        # TDAI replies to a source query with a bare index (!SRC(n)) and
-        # carries the name under a differently-shaped SRCNAME message
-        # instead - use that one if present, since a bare index alone is
-        # useless for populating names.
+        # Some models can't populate source names the default way:
+        # TDAI-1120/3400 carry the name under a differently-shaped SRCNAME
+        # message instead of the source-query reply; TDAI-2170 has a fixed
+        # hardware source list gated by a SRCENABLED bitmask rather than
+        # any enumeration burst at all.
         if self._model.supports_message(Msg.SOURCE_NAME):
             self._register_callback(Msg.SOURCE_NAME, self._source_name_callback)
+        elif self._model.supports_message(Msg.SOURCES_ENABLED):
+            self._register_callback(Msg.SOURCES_ENABLED, self._sources_enabled_callback)
+            self._register_callback(Msg.SOURCE, self._fixed_source_callback)
         else:
             self._register_callback(Msg.SOURCE, self._source_callback)
         self._register_callback(Msg.STREAM_TYPE, self._stream_type_callback)
@@ -183,13 +203,35 @@ class Receiver:
             Msg.ROOM_PERFECT_POSITIONS_COUNT,
             self._room_perfect_positions.count_callback,
         )
-        self._register_callback(
-            Msg.ROOM_PERFECT_POSITION, self._room_perfect_position_callback
-        )
+        # TDAI-2170 has a fixed set of RoomPerfect positions gated by an
+        # RPSTATUS bitmask rather than an RPLIST/RPFOCS enumeration burst.
+        if self._model.supports_message(Msg.ROOM_PERFECT_POSITIONS_PRESENT):
+            self._register_callback(
+                Msg.ROOM_PERFECT_POSITIONS_PRESENT,
+                self._room_perfect_positions_present_callback,
+            )
+            self._register_callback(
+                Msg.ROOM_PERFECT_POSITION,
+                self._fixed_room_perfect_position_callback,
+            )
+        else:
+            self._register_callback(
+                Msg.ROOM_PERFECT_POSITION, self._room_perfect_position_callback
+            )
         self._register_callback(
             Msg.ROOM_PERFECT_VOICINGS_COUNT, self._voicings.count_callback
         )
-        self._register_callback(Msg.ROOM_PERFECT_VOICING, self._voicing_callback)
+        # Same story for voicings: TDAI-2170 gates a fixed list with
+        # VOIENABLED rather than a VOILIST/RPVOIS burst.
+        if self._model.supports_message(Msg.ROOM_PERFECT_VOICINGS_ENABLED):
+            self._register_callback(
+                Msg.ROOM_PERFECT_VOICINGS_ENABLED, self._voicings_enabled_callback
+            )
+            self._register_callback(
+                Msg.ROOM_PERFECT_VOICING, self._fixed_voicing_callback
+            )
+        else:
+            self._register_callback(Msg.ROOM_PERFECT_VOICING, self._voicing_callback)
 
         # Trim and audio modes - not every model has these (the defensive
         # catch in _register_callback logs and skips whichever don't apply)
@@ -364,6 +406,20 @@ class Receiver:
         else:
             self._sources.add(int(index_str), name)
 
+    def _sources_enabled_callback(self, param1: str, param2: str) -> None:
+        """Handle a SRCENABLED reply (TDAI-2170): populate the fixed source
+        table filtered by which of its entries are enabled."""
+        self._populate_fixed_list(
+            self._sources, self._model.config.fixed_sources or {}, param1
+        )
+
+    def _fixed_source_callback(self, param1: str, param2: str) -> None:
+        """Handle a SRC reply on a model with a fixed source table
+        (TDAI-2170): the reply is a bare index with no name, so resolve it
+        against the table _sources_enabled_callback already populated."""
+        self._source = self._sources.get(int(param1))
+        self._notify_notification_callbacks()
+
     @property
     def available_sources(self) -> list[str]:
         return list(self._sources.values())
@@ -527,6 +583,25 @@ class Receiver:
         else:
             self._room_perfect_positions.add(int(param1), param2)
 
+    def _room_perfect_positions_present_callback(
+        self, param1: str, param2: str
+    ) -> None:
+        """Handle an RPSTATUS reply (TDAI-2170): populate the fixed
+        RoomPerfect position table filtered by which are present."""
+        self._populate_fixed_list(
+            self._room_perfect_positions,
+            self._model.config.room_perfect_positions or {},
+            param1,
+        )
+
+    def _fixed_room_perfect_position_callback(self, param1: str, param2: str) -> None:
+        """Handle an RP reply on a model with a fixed position table
+        (TDAI-2170): the reply is a bare index with no name, so resolve it
+        against the table _room_perfect_positions_present_callback already
+        populated."""
+        self._room_perfect_position = self._room_perfect_positions.get(int(param1))
+        self._notify_notification_callbacks()
+
     @property
     def available_room_perfect_positions(self) -> list[str]:
         return list(self._room_perfect_positions.values())
@@ -552,6 +627,20 @@ class Receiver:
             self._notify_notification_callbacks()
         else:
             self._voicings.add(int(param1), param2)
+
+    def _voicings_enabled_callback(self, param1: str, param2: str) -> None:
+        """Handle a VOIENABLED reply (TDAI-2170): populate the fixed
+        voicing table filtered by which are enabled."""
+        self._populate_fixed_list(
+            self._voicings, self._model.config.fixed_voicings or {}, param1
+        )
+
+    def _fixed_voicing_callback(self, param1: str, param2: str) -> None:
+        """Handle a VOI reply on a model with a fixed voicing table
+        (TDAI-2170): the reply is a bare index with no name, so resolve it
+        against the table _voicings_enabled_callback already populated."""
+        self._voicing = self._voicings.get(int(param1))
+        self._notify_notification_callbacks()
 
     @property
     def available_voicings(self) -> list[str]:

--- a/lyngdorf/models/base.py
+++ b/lyngdorf/models/base.py
@@ -56,7 +56,19 @@ class ModelConfig:
         audio_inputs: Audio input mapping (index -> name)
         stream_types: Stream type mapping (index -> name)
         video_outputs: Optional video output mapping
-        room_perfect_positions: Optional Room Perfect position mapping
+        room_perfect_positions: Fixed Room Perfect position mapping (index
+            -> name), used for models whose set of positions is hardware-
+            fixed rather than dynamically enumerated over the wire - see
+            `fixed_sources`.
+        fixed_sources: Fixed source mapping (index -> name), used for
+            models whose sources are fixed hardware inputs rather than a
+            dynamic, user-configurable list. TDAI-2170 is the only current
+            example: it has no count+enumeration burst for sources (no
+            SRCLIST), only a bitmask (SRCENABLED) of which of these fixed
+            entries are enabled. None for every model with a dynamic list.
+        fixed_voicings: Fixed voicing mapping (index -> name), same
+            rationale as `fixed_sources` but for voicings (gated by
+            VOIENABLED on TDAI-2170 rather than a VOILIST/RPVOIS burst).
         has_zone_b: Whether this model supports Zone B (Zone 2) functionality
         has_video: Whether this model supports video inputs/outputs
         has_surround: Whether this model has discrete per-channel
@@ -84,6 +96,8 @@ class ModelConfig:
     stream_types: dict[int, str]
     video_outputs: dict[int, str] | None = None
     room_perfect_positions: dict[int, str] | None = None
+    fixed_sources: dict[int, str] | None = None
+    fixed_voicings: dict[int, str] | None = None
     has_zone_b: bool = False
     has_video: bool = False
     has_surround: bool = False

--- a/lyngdorf/models/tdai_series.py
+++ b/lyngdorf/models/tdai_series.py
@@ -139,16 +139,29 @@ TDAI2170_MESSAGES: dict[Msg, str] = {
     Msg.SOURCE: "SRC",
     Msg.ROOM_PERFECT_POSITION: "RP",
     Msg.ROOM_PERFECT_VOICING: "VOI",
+    # This device has no count+enumeration burst for sources, RP
+    # positions, or voicings (no SRCLIST/RPLIST/VOILIST) - instead each
+    # has a fixed, hardware-defined set of entries (see the TDAI2170_*
+    # tables below) and a bitmask reply saying which of them are
+    # currently enabled/present. !SRC(n)/!RP(n)/!VOI(n) all reply with a
+    # bare index too, no name.
+    Msg.SOURCES_ENABLED: "SRCENABLED",
+    Msg.ROOM_PERFECT_POSITIONS_PRESENT: "RPSTATUS",
+    Msg.ROOM_PERFECT_VOICINGS_ENABLED: "VOIENABLED",
 }
 
 # TDAI-2170 Setup Sequence
 # SUBSCRIBE/SUBSCRIBEVOL activate push notifications for status/volume
-# changes (this device has no VERB feedback-level command).
+# changes (this device has no VERB feedback-level command). The bitmask
+# queries must come before the current-value queries they resolve against.
 TDAI2170_SETUP_MESSAGES: list[str] = [
     "SUBSCRIBE",
     "SUBSCRIBEVOL",
     f"{TDAI2170_MESSAGES[Msg.DEVICE]}?",
     f"{TDAI2170_MESSAGES[Msg.POWER]}?",
+    f"{TDAI2170_MESSAGES[Msg.SOURCES_ENABLED]}?",
+    f"{TDAI2170_MESSAGES[Msg.ROOM_PERFECT_POSITIONS_PRESENT]}?",
+    f"{TDAI2170_MESSAGES[Msg.ROOM_PERFECT_VOICINGS_ENABLED]}?",
     f"{TDAI2170_MESSAGES[Msg.SOURCE]}?",
     f"{TDAI2170_MESSAGES[Msg.ROOM_PERFECT_POSITION]}?",
     f"{TDAI2170_MESSAGES[Msg.ROOM_PERFECT_VOICING]}?",
@@ -182,6 +195,49 @@ TDAI2170_ROOM_PERFECT_POSITIONS = {
     9: "Global",
 }
 
+# Fixed hardware inputs (see docs/tdai-2170.md, Input Source Numbering).
+# Which of these are actually enabled comes from the SRCENABLED bitmask.
+TDAI2170_SOURCES = {
+    0: "Coax Digital 1",
+    1: "Coax Digital 2",
+    2: "Optical Digital 3",
+    3: "Optical Digital 4",
+    4: "Optical Digital 5",
+    5: "Optical Digital 6",
+    6: "USB Input",
+    7: "HDMI Input 1",
+    8: "HDMI Input 2",
+    9: "HDMI Input 3",
+    10: "HDMI Input 4",
+    11: "HDMI Audio Return Channel (ARC)",
+    12: "Analog 1 (RCA on main board)",
+    13: "Analog 2 (RCA on main board)",
+    14: "Analog 3 (RCA on extension board)",
+    15: "Analog 4 (RCA on extension board)",
+    16: "Analog 5 (RCA on extension board)",
+    17: "Analog 6 (XLR on extension board)",
+}
+
+# Fixed voicings (see docs/tdai-2170.md, Voicing Numbering). Which of these
+# are enabled comes from the VOIENABLED bitmask (Voicing 0/Neutral is
+# always enabled).
+TDAI2170_VOICINGS = {
+    0: "Neutral",
+    1: "Music 1",
+    2: "Music 2",
+    3: "Relaxed",
+    4: "Open",
+    5: "Open Air",
+    6: "Soft",
+    7: "Action 1",
+    8: "Action 2",
+    9: "Movie",
+    10: "Action Movie",
+    11: "News",
+    12: "Bass 1",
+    13: "Bass 2",
+}
+
 TDAI2170_CONFIG = ModelConfig(
     model_name="tdai-2170",
     manufacturer="Lyngdorf",
@@ -191,6 +247,8 @@ TDAI2170_CONFIG = ModelConfig(
     audio_inputs={},
     stream_types=TDAI2170_STREAM_TYPES,
     room_perfect_positions=TDAI2170_ROOM_PERFECT_POSITIONS,
+    fixed_sources=TDAI2170_SOURCES,
+    fixed_voicings=TDAI2170_VOICINGS,
     # Power and mute states are words, not digits: !PWR(ON), !MUTE(OFF)
     power_state_on=STATE_ON,
     mute_state_in_parameter=True,

--- a/tests/basic_wiring_test.py
+++ b/tests/basic_wiring_test.py
@@ -2601,6 +2601,132 @@ class TestTdaiSourceName:
 
 
 # =============================================================================
+# TDAI-2170 Fixed Lists
+#
+# TDAI-2170 has no count+enumeration burst for sources, RoomPerfect
+# positions, or voicings at all (no SRCLIST/RPLIST/VOILIST). Instead each
+# is a fixed, hardware-defined set of entries (baked into the library as
+# TDAI2170_SOURCES/TDAI2170_ROOM_PERFECT_POSITIONS/TDAI2170_VOICINGS) with
+# a bitmask reply (SRCENABLED/RPSTATUS/VOIENABLED) saying which entries
+# are currently enabled/present. !SRC(n)/!RP(n)/!VOI(n) reply with a bare
+# index and no name, so the current value must be resolved against the
+# table the bitmask already populated. See docs/tdai-2170.md.
+# =============================================================================
+
+
+class TestTdai2170FixedLists:
+    """TDAI-2170's bitmask-gated fixed lists must populate and resolve."""
+
+    future = None
+
+    def _callback(self, param1, param2):
+        if self.future is not None and not self.future.done():
+            self.future.set_result(True)
+
+    def test_tdai_2170_supports_the_bitmask_messages(self):
+        """TDAI-2170 has the three bitmask messages mapped."""
+        assert LyngdorfModel.TDAI_2170.supports_message(Msg.SOURCES_ENABLED) is True
+        assert (
+            LyngdorfModel.TDAI_2170.supports_message(Msg.ROOM_PERFECT_POSITIONS_PRESENT)
+            is True
+        )
+        assert (
+            LyngdorfModel.TDAI_2170.supports_message(Msg.ROOM_PERFECT_VOICINGS_ENABLED)
+            is True
+        )
+
+    def test_other_models_have_no_bitmask_messages(self):
+        """Every other model uses the default dynamic-list mechanism."""
+        for model in (
+            LyngdorfModel.MP_60,
+            LyngdorfModel.TDAI_1120,
+            LyngdorfModel.P_100,
+        ):
+            assert model.supports_message(Msg.SOURCES_ENABLED) is False
+            assert model.supports_message(Msg.ROOM_PERFECT_POSITIONS_PRESENT) is False
+            assert model.supports_message(Msg.ROOM_PERFECT_VOICINGS_ENABLED) is False
+
+    def test_populate_fixed_list_reads_bit0_as_rightmost_character(self):
+        """Bit 0 (source/position/voicing 0) is the rightmost character,
+        per the vendor manual's own bitmask example."""
+        from lyngdorf.base import CountingNumberDict
+
+        target = CountingNumberDict()
+        Receiver._populate_fixed_list(target, {0: "Bypass", 2: "Focus 2"}, "00000101")
+        assert target == {0: "Bypass", 2: "Focus 2"}
+
+    def test_populate_fixed_list_ignores_enabled_bits_outside_the_table(self):
+        """A bit set for an index the fixed table doesn't know about must
+        be skipped, not raise."""
+        from lyngdorf.base import CountingNumberDict
+
+        target = CountingNumberDict()
+        Receiver._populate_fixed_list(target, {0: "Bypass"}, "011")
+        assert target == {0: "Bypass"}
+
+    @pytest.mark.asyncio
+    async def test_sources_enabled_populates_and_resolves_current_source(self):
+        def test_function(client: Receiver):
+            assert client.available_sources == ["Coax Digital 1", "USB Input"]
+            assert client.source == "USB Input"
+
+        await self._receive(["!SRCENABLED(0000000001000001)", "!SRC(6)"], test_function)
+
+    @pytest.mark.asyncio
+    async def test_room_perfect_positions_present_populates_and_resolves(self):
+        def test_function(client: Receiver):
+            assert client.available_room_perfect_positions == ["Bypass", "Focus 2"]
+            assert client.room_perfect_position == "Focus 2"
+
+        await self._receive(["!RPSTATUS(00000101)", "!RP(2)"], test_function)
+
+    @pytest.mark.asyncio
+    async def test_voicings_enabled_populates_and_resolves_current_voicing(self):
+        def test_function(client: Receiver):
+            assert client.available_voicings == ["Neutral", "Music 2"]
+            assert client.voicing == "Music 2"
+
+        await self._receive(["!VOIENABLED(0000000000000101)", "!VOI(2)"], test_function)
+
+    @pytest.mark.asyncio
+    async def test_current_value_outside_enabled_set_resolves_to_none(self):
+        """If a current-value reply names an index the bitmask didn't
+        enable, resolving to None beats crashing on a missing key."""
+
+        def test_function(client: Receiver):
+            assert client.room_perfect_position is None
+
+        await self._receive(["!RPSTATUS(00000101)", "!RP(1)"], test_function)
+
+    async def _receive(self, commands_received, test_function):
+        """Feed raw TDAI-2170-shaped messages to a TDAI-2170 receiver."""
+        transport = mock.Mock()
+        protocol = LyngdorfProtocol(None, None)
+
+        def create_conn(proto_lambda, host, port):
+            proto = proto_lambda()
+            protocol._on_connection_lost = proto._on_connection_lost
+            protocol._on_message = proto._on_message
+            return [transport, proto]
+
+        client = await async_create_receiver(FAKE_IP, LyngdorfModel.TDAI_2170)
+
+        with mock.patch("asyncio.get_event_loop", new_callable=mock.Mock) as debug_mock:
+            debug_mock.return_value.create_connection = AsyncMock(
+                side_effect=create_conn
+            )
+            await client.async_connect()
+            self.future = asyncio.Future()
+            client._api.register_callback("DONE", self._callback)
+            protocol.data_received(
+                bytes("\r".join([*commands_received, "!DONE(0)"]) + "\r", "utf-8")
+            )
+            await self.future
+            test_function(client)
+            await client.async_disconnect()
+
+
+# =============================================================================
 # Message Framing
 #
 # Messages end with CR, but the TDAI family sends CR LF. Splitting on CR


### PR DESCRIPTION
## Problem

TDAI-2170 never populates \`available_sources\`, \`available_room_perfect_positions\`, or \`available_voicings\` - and their current-value counterparts (\`source\`, \`room_perfect_position\`, \`voicing\`) stay \`None\` too. Follow-up to #18.

## Root cause

Every other model enumerates these lists via a count+burst reply (\`SRCLIST?\`/\`RPLIST?\`/\`VOILIST?\` -> \`COUNT(N)\` + N named entries). TDAI-2170 has **none of these** - per \`docs/tdai-2170.md\`, each list is a fixed, hardware-defined set of entries, and the device only reports a **bitmask** of which entries are currently enabled/present:

| | list mechanism | current-value reply |
|---|---|---|
| every other model | count + N-named-entries burst | index + name together |
| TDAI-2170 sources | \`SRCENABLED?\` -> bitmask over a fixed 18-entry input table | \`!SRC(n)\` - bare index, no name |
| TDAI-2170 RP positions | \`RPSTATUS?\` -> bitmask over Bypass/Focus1-8/Global | \`!RP(n)\` - bare index, no name |
| TDAI-2170 voicings | \`VOIENABLED?\` -> bitmask over a fixed 14-entry voicing table | \`!VOI(n)\` - bare index, no name |

Bit 0 is the rightmost character of the bitmask string (per the manual's own \`!RPSTATUS(00000101)\` example).

## Fix

- \`ModelConfig.fixed_sources\` / \`fixed_voicings\` - new static index->name tables, parallel to the existing (but until now, never actually read anywhere) \`room_perfect_positions\` field. \`TDAI2170_SOURCES\`/\`TDAI2170_VOICINGS\` transcribed from the Input Source Numbering / Voicing Numbering appendices already in \`docs/tdai-2170.md\`.
- Three new \`Msg\` members mapped to \`SRCENABLED\`/\`RPSTATUS\`/\`VOIENABLED\`, TDAI-2170 only.
- \`Receiver._populate_fixed_list\`: one shared static helper that parses a bitmask and fills a \`CountingNumberDict\` from a model's fixed table - used by all three properties rather than three near-identical parsers.
- Three thin \"resolve a bare index against the table the bitmask already populated\" callbacks (one per property) - the existing count-burst callbacks' is-the-list-full? logic doesn't apply here since there's no burst to be full from.

\`async_connect()\` only takes this path when a model actually has these bitmask messages (\`supports_message\`) - every other model's registration is untouched.

**No public API changes** - \`source\`/\`room_perfect_position\`/\`voicing\`, their \`available_*\` properties, and their setters behave identically. Only the internal message wiring for TDAI-2170 changes.

## Verification

- 175 tests pass, \`black\`/\`ruff\`/\`mypy\` clean.
- New \`TestTdai2170FixedLists\`: bitmask parsing (including an enabled bit outside the known table, and a current-value index outside the enabled set - both handled without raising), and full round trips for all three properties.
- Confirmed against a **real MP-60** that \`source\`/\`room_perfect_position\`/\`voicing\` and their \`available_*\` lists are unaffected (unchanged code path).
- **Not yet verified against real TDAI-2170 hardware** - spec-derived from \`docs/tdai-2170.md\`. If anyone reading this has a TDAI-2170, a test would be very welcome.