### PR TITLE
Take the closing paren outside quotes, not the first one

### DIFF
--- a/lyngdorf/api.py
+++ b/lyngdorf/api.py
@@ -35,6 +35,28 @@ from .const import (
 _LOGGER = logging.getLogger(__package__)
 
 
+def _find_closing_paren(message: str, start: int) -> int:
+    """Index of the first ``)`` at or after ``start`` that is not inside a
+    quoted section, or -1 if there is none.
+
+    A plain ``find(")")`` is wrong for any model that puts the name inside
+    the parens. TDAI replies are shaped ``!SRCNAME(0,"Digital 1 (Coax)")``,
+    so the first ``)`` is the one closing "(Coax)" and the name is cut short.
+    Scanning past quoted sections keeps that intact while leaving the MP and
+    P shape - ``!SRC(0)"HDMI"``, name outside the parens - parsed exactly as
+    before. Note this is why ``rfind`` would not do instead: on the MP shape
+    the last ``)`` is the one inside the name.
+    """
+    in_quotes = False
+    for index in range(start, len(message)):
+        character = message[index]
+        if character == '"':
+            in_quotes = not in_quotes
+        elif character == ")" and not in_quotes:
+            return index
+    return -1
+
+
 class LyngdorfProtocol(asyncio.Protocol):
     """Protocol for the Lyngdorf interface."""
 
@@ -404,10 +426,14 @@ class LyngdorfApi:
             first: str = ""
             second: str = ""
             message = message[1:]
-            if 1 < message.find("(") < message.find(")"):
-                cmd = message[: message.find("(")]
-                first = message[1 + message.find("(") : message.find(")")]
-                second = message[1 + message.find(")") :]
+            open_index = message.find("(")
+            close_index = (
+                _find_closing_paren(message, open_index + 1) if open_index > 1 else -1
+            )
+            if close_index > open_index:
+                cmd = message[:open_index]
+                first = message[open_index + 1 : close_index]
+                second = message[close_index + 1 :]
             else:
                 cmd = message
 

--- a/tests/basic_wiring_test.py
+++ b/tests/basic_wiring_test.py
@@ -2775,3 +2775,98 @@ class TestMessageFraming:
         assert self._collect(b'!SRCNAME(6,"A2 HT Bypass Adam")\r\n') == [
             '!SRCNAME(6,"A2 HT Bypass Adam")'
         ]
+
+
+# =============================================================================
+# Message Parameter Parsing
+#
+# The parameter parser serves every model, and the two families put the
+# source name on opposite sides of the closing paren:
+#
+#   MP / P            !SRC(0)"HDMI"              name OUTSIDE
+#   TDAI-1120/3400    !SRCNAME(0,"HDMI")         name INSIDE
+#
+# So a name containing ")" breaks a naive scan from whichever end. Taking
+# the first ")" cuts the TDAI shape short; taking the last one cuts the MP
+# shape short. The closing paren is the first one outside quotes.
+#
+# Observed on a real TDAI-1120, whose sources are named "Digital 1 (Coax)"
+# and similar: four of fourteen arrived clipped.
+# =============================================================================
+
+
+class TestMessageParameterParsing:
+    """Parameters must survive names containing parentheses, both shapes."""
+
+    @staticmethod
+    async def _parse(model, raw):
+        """Feed one raw message to the parser, return (cmd, first, second)."""
+        api = LyngdorfApi(FAKE_IP, model)
+        seen: list[tuple[str, str, str]] = []
+        command = raw[1:].split("(")[0].split('"')[0]
+        api.register_callback(command, lambda p1, p2: seen.append((command, p1, p2)))
+        api._process_event(raw)
+        await asyncio.sleep(0.01)
+        return seen[0] if seen else None
+
+    @pytest.mark.asyncio
+    async def test_tdai_source_name_with_parens_is_not_truncated(self):
+        """The reported bug: `Digital 1 (Coax)` lost its closing paren."""
+        result = await self._parse(
+            LyngdorfModel.TDAI_1120, '!SRCNAME(0,"Digital 1 (Coax)")'
+        )
+        assert result == ("SRCNAME", '0,"Digital 1 (Coax)"', "")
+
+    @pytest.mark.asyncio
+    async def test_tdai_source_name_without_parens_unchanged(self):
+        """Names with no parens must parse exactly as before."""
+        result = await self._parse(
+            LyngdorfModel.TDAI_1120, '!SRCNAME(6,"A2 HT Bypass Adam")'
+        )
+        assert result == ("SRCNAME", '6,"A2 HT Bypass Adam"', "")
+
+    @pytest.mark.asyncio
+    async def test_mp_name_outside_parens_unchanged(self):
+        """MP puts the name after the parens; that split must not move."""
+        result = await self._parse(LyngdorfModel.MP_60, '!SRC(0)"HDMI"')
+        assert result == ("SRC", "0", "HDMI")
+
+    @pytest.mark.asyncio
+    async def test_mp_name_outside_parens_containing_parens(self):
+        """The case that rules out rfind: on MP the last ) is in the name."""
+        result = await self._parse(LyngdorfModel.MP_60, '!SRC(0)"Zone (2)"')
+        assert result == ("SRC", "0", "Zone (2)")
+
+    @pytest.mark.asyncio
+    async def test_simple_parameter_unchanged(self):
+        """The common single-value reply."""
+        assert await self._parse(LyngdorfModel.TDAI_1120, "!PWR(ON)") == (
+            "PWR",
+            "ON",
+            "",
+        )
+
+    @pytest.mark.asyncio
+    async def test_negative_numeric_parameter_unchanged(self):
+        """Volume, the other reply this parser handles constantly."""
+        assert await self._parse(LyngdorfModel.TDAI_1120, "!VOL(-350)") == (
+            "VOL",
+            "-350",
+            "",
+        )
+
+    @pytest.mark.asyncio
+    async def test_message_with_no_parens_is_command_only(self):
+        """Bare commands (e.g. MUTEON) carry no parameters."""
+        assert await self._parse(LyngdorfModel.MP_60, "!MUTEON") == (
+            "MUTEON",
+            "",
+            "",
+        )
+
+    @pytest.mark.asyncio
+    async def test_unterminated_quote_is_ignored_not_half_applied(self):
+        """A reply with no closing paren outside quotes has no usable
+        parameter, so it falls to the pre-existing command-only branch and
+        no SRCNAME callback fires. Better ignored than half-parsed."""
+        assert await self._parse(LyngdorfModel.TDAI_1120, '!SRCNAME(0,"oops') is None


### PR DESCRIPTION
Fixes #20.

`_process_event` used `find(")")` for the end of the parameter. The two protocol families put the source name on opposite sides of it:

```
MP / P            !SRC(0)"HDMI"          name OUTSIDE the parens
TDAI-1120/3400    !SRCNAME(0,"HDMI")     name INSIDE
```

So on the TDAI shape a `)` in the name terminates the parameter early:

```
!SRCNAME(0,"Digital 1 (Coax)")
         ^ param starts   ^ first ) is here

first = '0,"Digital 1 (Coax'
```

On a real TDAI-1120, four of fourteen sources arrived clipped.

## Fix

Scan for the first `)` that is not inside a quoted section.

`rfind` would not work instead: on the MP shape the last `)` is the one *inside* the name, so it would break the family this currently works for. There's a test for that case (`!SRC(0)"Zone (2)"`) to keep the two shapes honest.

No callback changes needed — `_source_name_callback` already partitions on the first comma and strips quotes, so it yields the full name once the parameter arrives intact.

## Verified on hardware

TDAI-1120, before and after:

```
before                after
Digital 1 (Coax   ->  Digital 1 (Coax)
Digital 2 (Coax   ->  Digital 2 (Coax)
Digital 3 (Opt.   ->  Digital 3 (Opt.)
Digital 4 (Opt.   ->  Digital 4 (Opt.)
```

The other ten were already correct and are unchanged. `power_on`, `mute_enabled` and `volume` unaffected.

## Tests

183 pass; `black`, `ruff`, `mypy` clean. New `TestMessageParameterParsing` covers both families:

- TDAI name containing `)` — the reported bug
- TDAI name without parens — unchanged
- MP name outside the parens — unchanged
- MP name containing `)` — the case that rules out `rfind`
- simple and negative-numeric parameters (`!PWR(ON)`, `!VOL(-350)`)
- bare command with no parens (`!MUTEON`)
- unterminated quote — falls to the existing command-only branch and is ignored rather than half-applied

Only the first fails without the fix; the rest are there to pin the behaviour that must not move.