### PR TITLE
Fix TDAI-1120/3400 RoomPerfect and voicing names never populating

### DIFF
--- a/lyngdorf/const.py
+++ b/lyngdorf/const.py
@@ -89,11 +89,13 @@ Msg = Enum(
         "ROOM_PERFECT_POSITION",
         "ROOM_PERFECT_POSITIONS",  # Room Perfect position list query
         "ROOM_PERFECT_POSITION_LIST",  # TDAI Room Perfect position list query
+        "ROOM_PERFECT_POSITION_NAME",  # TDAI current-position-with-name query / list-population key
         "ROOM_PERFECT_POSITIONS_PRESENT",  # TDAI-2170 bitmask of which fixed positions are present
         "ROOM_PERFECT_VOICINGS_COUNT",
         "ROOM_PERFECT_VOICING",
         "ROOM_PERFECT_VOICINGS",  # Room Perfect voicing list query
         "ROOM_PERFECT_VOICING_LIST",  # TDAI Room Perfect voicing list query
+        "ROOM_PERFECT_VOICING_NAME",  # TDAI current-voicing-with-name query / list-population key
         "ROOM_PERFECT_VOICINGS_ENABLED",  # TDAI-2170 bitmask of which fixed voicings are enabled
         "LIP_SYNC",
         "LIP_SYNC_MIN_MAX",

--- a/lyngdorf/device.py
+++ b/lyngdorf/device.py
@@ -214,6 +214,12 @@ class Receiver:
                 Msg.ROOM_PERFECT_POSITION,
                 self._fixed_room_perfect_position_callback,
             )
+        elif self._model.supports_message(Msg.ROOM_PERFECT_POSITION_NAME):
+            # TDAI-1120/3400 carry the name under RPNAME, comma-packed
+            self._register_callback(
+                Msg.ROOM_PERFECT_POSITION_NAME,
+                self._room_perfect_position_name_callback,
+            )
         else:
             self._register_callback(
                 Msg.ROOM_PERFECT_POSITION, self._room_perfect_position_callback
@@ -229,6 +235,11 @@ class Receiver:
             )
             self._register_callback(
                 Msg.ROOM_PERFECT_VOICING, self._fixed_voicing_callback
+            )
+        elif self._model.supports_message(Msg.ROOM_PERFECT_VOICING_NAME):
+            # TDAI-1120/3400 carry the name under VOINAME, comma-packed
+            self._register_callback(
+                Msg.ROOM_PERFECT_VOICING_NAME, self._voicing_name_callback
             )
         else:
             self._register_callback(Msg.ROOM_PERFECT_VOICING, self._voicing_callback)
@@ -583,6 +594,21 @@ class Receiver:
         else:
             self._room_perfect_positions.add(int(param1), param2)
 
+    def _room_perfect_position_name_callback(self, param1: str, param2: str):
+        """Handle an RPNAME reply (TDAI-1120/3400): index and name arrive
+        comma-separated inside one set of parens - !RPNAME(0,"Bypass") -
+        rather than split into two fields the way MP's !RPFOC(0)"Bypass"
+        is, so this can't reuse _room_perfect_position_callback's parsing.
+        Mirrors _source_name_callback.
+        """
+        index_str, _, name = param1.partition(",")
+        name = name.strip('"')
+        if self._room_perfect_positions.is_full():
+            self._room_perfect_position = name
+            self._notify_notification_callbacks()
+        else:
+            self._room_perfect_positions.add(int(index_str), name)
+
     def _room_perfect_positions_present_callback(
         self, param1: str, param2: str
     ) -> None:
@@ -627,6 +653,18 @@ class Receiver:
             self._notify_notification_callbacks()
         else:
             self._voicings.add(int(param1), param2)
+
+    def _voicing_name_callback(self, param1: str, param2: str):
+        """Handle a VOINAME reply (TDAI-1120/3400): same comma-packed shape
+        as RPNAME and SRCNAME - !VOINAME(0,"Neutral").
+        """
+        index_str, _, name = param1.partition(",")
+        name = name.strip('"')
+        if self._voicings.is_full():
+            self._voicing = name
+            self._notify_notification_callbacks()
+        else:
+            self._voicings.add(int(index_str), name)
 
     def _voicings_enabled_callback(self, param1: str, param2: str) -> None:
         """Handle a VOIENABLED reply (TDAI-2170): populate the fixed

--- a/lyngdorf/models/tdai_series.py
+++ b/lyngdorf/models/tdai_series.py
@@ -52,9 +52,15 @@ TDAI_MESSAGES: dict[Msg, str] = {
     Msg.ROOM_PERFECT_POSITIONS_COUNT: "RPCOUNT",
     Msg.ROOM_PERFECT_POSITION: "RP",
     Msg.ROOM_PERFECT_POSITION_LIST: "RPLIST",
+    # Same shape as SRCNAME above: !RP? replies with a bare index, and
+    # both the RPLIST? burst and the current-position query carry the
+    # name under RPNAME instead - !RPNAME(n,"Name").
+    Msg.ROOM_PERFECT_POSITION_NAME: "RPNAME",
     Msg.ROOM_PERFECT_VOICINGS_COUNT: "VOICOUNT",
     Msg.ROOM_PERFECT_VOICING: "VOI",
     Msg.ROOM_PERFECT_VOICING_LIST: "VOILIST",
+    # And again for voicings: !VOINAME(n,"Name").
+    Msg.ROOM_PERFECT_VOICING_NAME: "VOINAME",
     Msg.TRIM_BASS: "BASS",
     Msg.TRIM_TREBLE: "TREBLE",
     Msg.BALANCE: "BAL",
@@ -71,8 +77,10 @@ TDAI_SETUP_MESSAGES: list[str] = [
     # SRCNAME?, not SRC? - the current-source query needs the name, and
     # !SRC? doesn't carry one (see Msg.SOURCE_NAME above).
     f"{TDAI_MESSAGES[Msg.SOURCE_NAME]}?",
-    f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_POSITION]}?",
-    f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_VOICING]}?",
+    # RPNAME?/VOINAME? rather than RP?/VOI?, for the same reason as
+    # SRCNAME? above - the bare queries carry no name.
+    f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_POSITION_NAME]}?",
+    f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_VOICING_NAME]}?",
     f"{TDAI_MESSAGES[Msg.STREAM_TYPE]}?",
     f"{TDAI_MESSAGES[Msg.VOLUME]}?",
     f"{TDAI_MESSAGES[Msg.MUTE]}?",

--- a/tests/basic_wiring_test.py
+++ b/tests/basic_wiring_test.py
@@ -2775,3 +2775,120 @@ class TestMessageFraming:
         assert self._collect(b'!SRCNAME(6,"A2 HT Bypass Adam")\r\n') == [
             '!SRCNAME(6,"A2 HT Bypass Adam")'
         ]
+
+
+# =============================================================================
+# TDAI RoomPerfect / Voicing Names
+#
+# Same shape, and same gap, as SRCNAME had before it was mapped:
+#
+#   !RPLIST?   ->  !RPCOUNT(3)    !RPNAME(0,"Bypass")   ...
+#   !VOILIST?  ->  !VOICOUNT(14)  !VOINAME(0,"Neutral") ...
+#
+# !RP? and !VOI? reply with a bare index and no name, so without RPNAME
+# and VOINAME mapped nothing is registered to receive the names and
+# room_perfect_position / voicing stay None on a TDAI-1120/3400.
+#
+# Indices are non-contiguous on real hardware - a TDAI-1120 returns
+# RoomPerfect 0, 1 and 9 - so an index is not a position in the list.
+# =============================================================================
+
+
+class TestTdaiRoomPerfectAndVoicingNames:
+    """RPNAME/VOINAME must populate the lists and the current selection."""
+
+    future = None
+
+    def _callback(self, param1, param2):
+        if self.future is not None and not self.future.done():
+            self.future.set_result(True)
+
+    def test_tdai_maps_rpname_and_voiname(self):
+        """TDAI-1120/3400 speak the name-bearing variants."""
+        for model in (LyngdorfModel.TDAI_1120, LyngdorfModel.TDAI_3400):
+            assert model.lookup_command(Msg.ROOM_PERFECT_POSITION_NAME) == "RPNAME"
+            assert model.lookup_command(Msg.ROOM_PERFECT_VOICING_NAME) == "VOINAME"
+
+    def test_other_models_do_not(self):
+        """MP, P and the TDAI-2170 use their existing mechanisms."""
+        for model in (
+            LyngdorfModel.MP_60,
+            LyngdorfModel.P_100,
+            LyngdorfModel.TDAI_2170,
+        ):
+            assert not model.supports_message(Msg.ROOM_PERFECT_POSITION_NAME)
+            assert not model.supports_message(Msg.ROOM_PERFECT_VOICING_NAME)
+
+    def test_setup_queries_the_name_bearing_form(self):
+        """RPNAME?/VOINAME? replace the nameless RP?/VOI? in setup."""
+        from lyngdorf.const import TDAI1120_SETUP_MESSAGES
+
+        assert "RPNAME?" in TDAI1120_SETUP_MESSAGES
+        assert "VOINAME?" in TDAI1120_SETUP_MESSAGES
+
+    @pytest.mark.asyncio
+    async def test_room_perfect_positions_populate_and_current_is_set(self):
+        """Non-contiguous indices, then a later RPNAME as the selection."""
+
+        def check(client: Receiver):
+            assert client.available_room_perfect_positions == [
+                "Bypass",
+                "Focus",
+                "Global",
+            ]
+            assert client.room_perfect_position == "Focus"
+
+        await self._receive(
+            [
+                "!RPCOUNT(3)",
+                '!RPNAME(0,"Bypass")',
+                '!RPNAME(1,"Focus")',
+                '!RPNAME(9,"Global")',
+                '!RPNAME(1,"Focus")',
+                "!BAL(0)",
+            ],
+            check,
+        )
+
+    @pytest.mark.asyncio
+    async def test_voicings_populate_and_current_is_set(self):
+        """Same for voicings."""
+
+        def check(client: Receiver):
+            assert client.available_voicings == ["Neutral", "Music", "Movie"]
+            assert client.voicing == "Movie"
+
+        await self._receive(
+            [
+                "!VOICOUNT(3)",
+                '!VOINAME(0,"Neutral")',
+                '!VOINAME(1,"Music")',
+                '!VOINAME(9,"Movie")',
+                '!VOINAME(9,"Movie")',
+                "!BAL(0)",
+            ],
+            check,
+        )
+
+    async def _receive(self, commands_received, test_function):
+        transport = mock.Mock()
+        protocol = LyngdorfProtocol(None, None)
+
+        def create_conn(proto_lambda, host, port):
+            proto = proto_lambda()
+            protocol._on_connection_lost = proto._on_connection_lost
+            protocol._on_message = proto._on_message
+            return [transport, proto]
+
+        client = await async_create_receiver(FAKE_IP, LyngdorfModel.TDAI_1120)
+        with mock.patch("asyncio.get_event_loop", new_callable=mock.Mock) as debug_mock:
+            debug_mock.return_value.create_connection = AsyncMock(
+                side_effect=create_conn
+            )
+            await client.async_connect()
+            self.future = asyncio.Future()
+            client._api.register_callback("BAL", self._callback)
+            protocol.data_received(bytes("\r".join(commands_received) + "\r", "utf-8"))
+            await self.future
+            test_function(client)
+            await client.async_disconnect()


### PR DESCRIPTION
Fixes #21.

The same gap `SRCNAME` had, in the two remaining places. `!RP?` and `!VOI?` reply with a bare index and no name; the name-bearing replies — both the list-population bursts and the current-selection queries — are keyed under `RPNAME` and `VOINAME`:

```
!RPLIST?   ->  !RPCOUNT(3)    !RPNAME(0,"Bypass")   !RPNAME(1,"Focus")  !RPNAME(9,"Global")
!VOILIST?  ->  !VOICOUNT(14)  !VOINAME(0,"Neutral") ...                 !VOINAME(13,"Bass 2")
```

Neither was in `TDAI_MESSAGES`, so nothing was registered to receive them and `room_perfect_position` / `voicing` both read `None` on a TDAI-1120.

## Fix

Mirrors #18 exactly:

- new `Msg.ROOM_PERFECT_POSITION_NAME` / `Msg.ROOM_PERFECT_VOICING_NAME`, mapped for TDAI-1120 and TDAI-3400 only
- `_room_perfect_position_name_callback` / `_voicing_name_callback`, splitting the comma-packed `index,"name"` before the same is-the-list-full? logic
- `async_connect()` picks whichever message the model supports, so MP, P and the TDAI-2170 keep their existing paths
- setup sequence queries `RPNAME?` / `VOINAME?` rather than the nameless `RP?` / `VOI?`

No public API changes — `room_perfect_position`, `voicing` and their `available_*` lists behave identically. Only the wiring that fills them.

## This is not what #19 fixed

Worth stating since the titles overlap. #19 added `SRCENABLED` / `RPSTATUS` / `VOIENABLED` to `TDAI2170_MESSAGES`, for the 2170's *fixed* hardware lists gated by a bitmask. The 1120 and 3400 enumerate theirs over the wire instead, and `TDAI_MESSAGES` was untouched. Confirmed by testing `1.4.3`, which already contains #19, and still reading `None` for both.

## Verified on hardware

TDAI-1120:

```
before                          after
room_perfect_position: None  -> 'Focus'
voicing:               None  -> 'Movie'
```

`power_on`, `mute_enabled`, `volume` and the source list unaffected.

One note from the amp: **indices are non-contiguous.** RoomPerfect returns 0, 1, 9 — there are ten possible positions but only three configured. The count-based population handles it, but it rules out treating an index as a position in the list, so the tests use non-contiguous indices deliberately.

## Tests

180 pass; `black`, `ruff`, `mypy` clean. New `TestTdaiRoomPerfectAndVoicingNames` covers the mappings, that MP/P/2170 do *not* get them, the setup sequence, and both list-then-select round trips with non-contiguous indices. All five fail without the fix.