### PR TITLE
Fix name truncation on ')' and TDAI-1120/3400 RP/voicing names

### DIFF
--- a/lyngdorf/api.py
+++ b/lyngdorf/api.py
@@ -393,6 +393,41 @@ class LyngdorfApi:
     def trim_treble_down(self):
         self._writeCommand(f"{self._model.lookup_command(Msg.TRIM_TREBLE_SET)}-")
 
+    @staticmethod
+    def _split_command(message: str) -> tuple[str, str, str]:
+        """Split a "CMD(param)trailing" message into (cmd, param, trailing).
+
+        The closing paren is matched quote-aware: a bare `message.find(")")`
+        would stop at the first `)`, which is wrong when a quoted name
+        itself contains one - e.g. `!SRCNAME(0,"Digital 1 (Coax)")` would
+        otherwise be split as if the parameter were `0,"Digital 1 (Coax`,
+        truncating the name and misparsing everything after it as
+        "trailing". A `)` inside a quoted section is never the
+        parameter's own terminator.
+        """
+        open_paren = message.find("(")
+        if not 1 < open_paren:
+            return message, "", ""
+
+        in_quotes = False
+        close_paren = -1
+        for i in range(open_paren + 1, len(message)):
+            char = message[i]
+            if char == '"':
+                in_quotes = not in_quotes
+            elif char == ")" and not in_quotes:
+                close_paren = i
+                break
+
+        if close_paren <= open_paren:
+            return message, "", ""
+
+        return (
+            message[:open_paren],
+            message[open_paren + 1 : close_paren],
+            message[close_paren + 1 :],
+        )
+
     def _process_event(self, message: str) -> None:
         """Process a realtime event."""
 
@@ -400,16 +435,8 @@ class LyngdorfApi:
         # print("\r"+message+"\r")
         self._last_message_time = time.monotonic()
         if message.startswith("!"):
-            cmd: str = ""
-            first: str = ""
-            second: str = ""
             message = message[1:]
-            if 1 < message.find("(") < message.find(")"):
-                cmd = message[: message.find("(")]
-                first = message[1 + message.find("(") : message.find(")")]
-                second = message[1 + message.find(")") :]
-            else:
-                cmd = message
+            cmd, first, second = self._split_command(message)
 
             try:
                 pong_command = self._model.lookup_command(Msg.PONG)

--- a/lyngdorf/const.py
+++ b/lyngdorf/const.py
@@ -89,11 +89,13 @@ Msg = Enum(
         "ROOM_PERFECT_POSITION",
         "ROOM_PERFECT_POSITIONS",  # Room Perfect position list query
         "ROOM_PERFECT_POSITION_LIST",  # TDAI Room Perfect position list query
+        "ROOM_PERFECT_POSITION_NAME",  # TDAI-1120/3400 current-position-with-name query / list-population key
         "ROOM_PERFECT_POSITIONS_PRESENT",  # TDAI-2170 bitmask of which fixed positions are present
         "ROOM_PERFECT_VOICINGS_COUNT",
         "ROOM_PERFECT_VOICING",
         "ROOM_PERFECT_VOICINGS",  # Room Perfect voicing list query
         "ROOM_PERFECT_VOICING_LIST",  # TDAI Room Perfect voicing list query
+        "ROOM_PERFECT_VOICING_NAME",  # TDAI-1120/3400 current-voicing-with-name query / list-population key
         "ROOM_PERFECT_VOICINGS_ENABLED",  # TDAI-2170 bitmask of which fixed voicings are enabled
         "LIP_SYNC",
         "LIP_SYNC_MIN_MAX",

--- a/lyngdorf/device.py
+++ b/lyngdorf/device.py
@@ -203,9 +203,15 @@ class Receiver:
             Msg.ROOM_PERFECT_POSITIONS_COUNT,
             self._room_perfect_positions.count_callback,
         )
-        # TDAI-2170 has a fixed set of RoomPerfect positions gated by an
-        # RPSTATUS bitmask rather than an RPLIST/RPFOCS enumeration burst.
-        if self._model.supports_message(Msg.ROOM_PERFECT_POSITIONS_PRESENT):
+        # TDAI-1120/3400 carry the position name under a differently-shaped
+        # RPNAME message; TDAI-2170 has a fixed set of positions gated by
+        # an RPSTATUS bitmask instead of an RPLIST/RPFOCS enumeration burst.
+        if self._model.supports_message(Msg.ROOM_PERFECT_POSITION_NAME):
+            self._register_callback(
+                Msg.ROOM_PERFECT_POSITION_NAME,
+                self._room_perfect_position_name_callback,
+            )
+        elif self._model.supports_message(Msg.ROOM_PERFECT_POSITIONS_PRESENT):
             self._register_callback(
                 Msg.ROOM_PERFECT_POSITIONS_PRESENT,
                 self._room_perfect_positions_present_callback,
@@ -221,9 +227,14 @@ class Receiver:
         self._register_callback(
             Msg.ROOM_PERFECT_VOICINGS_COUNT, self._voicings.count_callback
         )
-        # Same story for voicings: TDAI-2170 gates a fixed list with
-        # VOIENABLED rather than a VOILIST/RPVOIS burst.
-        if self._model.supports_message(Msg.ROOM_PERFECT_VOICINGS_ENABLED):
+        # Same story for voicings: TDAI-1120/3400 use a differently-shaped
+        # VOINAME message; TDAI-2170 gates a fixed list with VOIENABLED
+        # rather than a VOILIST/RPVOIS burst.
+        if self._model.supports_message(Msg.ROOM_PERFECT_VOICING_NAME):
+            self._register_callback(
+                Msg.ROOM_PERFECT_VOICING_NAME, self._voicing_name_callback
+            )
+        elif self._model.supports_message(Msg.ROOM_PERFECT_VOICINGS_ENABLED):
             self._register_callback(
                 Msg.ROOM_PERFECT_VOICINGS_ENABLED, self._voicings_enabled_callback
             )
@@ -583,6 +594,18 @@ class Receiver:
         else:
             self._room_perfect_positions.add(int(param1), param2)
 
+    def _room_perfect_position_name_callback(self, param1: str, param2: str):
+        """Handle an RPNAME reply (TDAI-1120/3400): index and name arrive
+        comma-separated inside one set of parens, same shape as SRCNAME -
+        see _source_name_callback."""
+        index_str, _, name = param1.partition(",")
+        name = name.strip('"')
+        if self._room_perfect_positions.is_full():
+            self._room_perfect_position = name
+            self._notify_notification_callbacks()
+        else:
+            self._room_perfect_positions.add(int(index_str), name)
+
     def _room_perfect_positions_present_callback(
         self, param1: str, param2: str
     ) -> None:
@@ -627,6 +650,18 @@ class Receiver:
             self._notify_notification_callbacks()
         else:
             self._voicings.add(int(param1), param2)
+
+    def _voicing_name_callback(self, param1: str, param2: str):
+        """Handle a VOINAME reply (TDAI-1120/3400): index and name arrive
+        comma-separated inside one set of parens, same shape as SRCNAME -
+        see _source_name_callback."""
+        index_str, _, name = param1.partition(",")
+        name = name.strip('"')
+        if self._voicings.is_full():
+            self._voicing = name
+            self._notify_notification_callbacks()
+        else:
+            self._voicings.add(int(index_str), name)
 
     def _voicings_enabled_callback(self, param1: str, param2: str) -> None:
         """Handle a VOIENABLED reply (TDAI-2170): populate the fixed

--- a/lyngdorf/models/tdai_series.py
+++ b/lyngdorf/models/tdai_series.py
@@ -52,9 +52,15 @@ TDAI_MESSAGES: dict[Msg, str] = {
     Msg.ROOM_PERFECT_POSITIONS_COUNT: "RPCOUNT",
     Msg.ROOM_PERFECT_POSITION: "RP",
     Msg.ROOM_PERFECT_POSITION_LIST: "RPLIST",
+    # Same story as SOURCE_NAME above: !RP? replies with a bare index, no
+    # name. The list-population burst and the current-position query are
+    # both keyed under RPNAME instead.
+    Msg.ROOM_PERFECT_POSITION_NAME: "RPNAME",
     Msg.ROOM_PERFECT_VOICINGS_COUNT: "VOICOUNT",
     Msg.ROOM_PERFECT_VOICING: "VOI",
     Msg.ROOM_PERFECT_VOICING_LIST: "VOILIST",
+    # Same story again: !VOI? replies with a bare index, no name.
+    Msg.ROOM_PERFECT_VOICING_NAME: "VOINAME",
     Msg.TRIM_BASS: "BASS",
     Msg.TRIM_TREBLE: "TREBLE",
     Msg.BALANCE: "BAL",
@@ -68,11 +74,13 @@ TDAI_SETUP_MESSAGES: list[str] = [
     f"{TDAI_MESSAGES[Msg.SOURCE_LIST]}?",
     f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_POSITION_LIST]}?",
     f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_VOICING_LIST]}?",
-    # SRCNAME?, not SRC? - the current-source query needs the name, and
-    # !SRC? doesn't carry one (see Msg.SOURCE_NAME above).
+    # SRCNAME?/RPNAME?/VOINAME?, not SRC?/RP?/VOI? - the current-value
+    # queries need the name, and the bare forms don't carry one (see
+    # Msg.SOURCE_NAME/ROOM_PERFECT_POSITION_NAME/ROOM_PERFECT_VOICING_NAME
+    # above).
     f"{TDAI_MESSAGES[Msg.SOURCE_NAME]}?",
-    f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_POSITION]}?",
-    f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_VOICING]}?",
+    f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_POSITION_NAME]}?",
+    f"{TDAI_MESSAGES[Msg.ROOM_PERFECT_VOICING_NAME]}?",
     f"{TDAI_MESSAGES[Msg.STREAM_TYPE]}?",
     f"{TDAI_MESSAGES[Msg.VOLUME]}?",
     f"{TDAI_MESSAGES[Msg.MUTE]}?",

--- a/tests/basic_wiring_test.py
+++ b/tests/basic_wiring_test.py
@@ -2601,6 +2601,134 @@ class TestTdaiSourceName:
 
 
 # =============================================================================
+# TDAI RoomPerfect/Voicing Names
+#
+# Same story as SRCNAME: !RP?/!VOI? on TDAI-1120/3400 reply with a bare
+# index, no name. The name-bearing replies (both the RPLIST?/VOILIST?
+# list-population burst and the current-value query) are keyed under
+# RPNAME/VOINAME instead, comma-packed the same way SRCNAME is - found
+# via real TDAI-1120 hardware testing (PR #18 follow-up).
+# =============================================================================
+
+
+class TestTdaiRoomPerfectAndVoicingName:
+    """TDAI-1120/3400 RP position and voicing names must populate."""
+
+    future = None
+
+    def _callback(self, param1, param2):
+        if self.future is not None and not self.future.done():
+            self.future.set_result(True)
+
+    def test_tdai_1120_and_3400_support_position_and_voicing_name(self):
+        assert (
+            LyngdorfModel.TDAI_1120.supports_message(Msg.ROOM_PERFECT_POSITION_NAME)
+            is True
+        )
+        assert (
+            LyngdorfModel.TDAI_3400.supports_message(Msg.ROOM_PERFECT_POSITION_NAME)
+            is True
+        )
+        assert (
+            LyngdorfModel.TDAI_1120.supports_message(Msg.ROOM_PERFECT_VOICING_NAME)
+            is True
+        )
+        assert (
+            LyngdorfModel.TDAI_3400.supports_message(Msg.ROOM_PERFECT_VOICING_NAME)
+            is True
+        )
+
+    def test_tdai_2170_and_others_have_no_position_or_voicing_name(self):
+        """TDAI-2170 resolves these via its own fixed-list/bitmask
+        mechanism instead (see TestTdai2170FixedLists). MP/P never needed
+        one since their RP/VOI reply already carries a name."""
+        for model in (
+            LyngdorfModel.TDAI_2170,
+            LyngdorfModel.MP_60,
+            LyngdorfModel.P_100,
+        ):
+            assert model.supports_message(Msg.ROOM_PERFECT_POSITION_NAME) is False
+            assert model.supports_message(Msg.ROOM_PERFECT_VOICING_NAME) is False
+
+    @pytest.mark.asyncio
+    async def test_room_perfect_position_list_populates_names(self):
+        def test_function(client: Receiver):
+            assert client.available_room_perfect_positions == ["Bypass", "Focus"]
+
+        await self._receive(
+            ["!RPCOUNT(2)", '!RPNAME(0,"Bypass")', '!RPNAME(1,"Focus")'],
+            test_function,
+        )
+
+    @pytest.mark.asyncio
+    async def test_current_room_perfect_position_resolves_after_list_is_full(self):
+        def test_function(client: Receiver):
+            assert client.room_perfect_position == "Focus"
+
+        await self._receive(
+            [
+                "!RPCOUNT(2)",
+                '!RPNAME(0,"Bypass")',
+                '!RPNAME(1,"Focus")',
+                '!RPNAME(1,"Focus")',
+            ],
+            test_function,
+        )
+
+    @pytest.mark.asyncio
+    async def test_voicing_list_populates_names(self):
+        def test_function(client: Receiver):
+            assert client.available_voicings == ["Neutral", "Music"]
+
+        await self._receive(
+            ["!VOICOUNT(2)", '!VOINAME(0,"Neutral")', '!VOINAME(1,"Music")'],
+            test_function,
+        )
+
+    @pytest.mark.asyncio
+    async def test_current_voicing_resolves_after_list_is_full(self):
+        def test_function(client: Receiver):
+            assert client.voicing == "Music"
+
+        await self._receive(
+            [
+                "!VOICOUNT(2)",
+                '!VOINAME(0,"Neutral")',
+                '!VOINAME(1,"Music")',
+                '!VOINAME(1,"Music")',
+            ],
+            test_function,
+        )
+
+    async def _receive(self, commands_received, test_function):
+        """Feed raw TDAI-shaped messages to a TDAI-1120 receiver."""
+        transport = mock.Mock()
+        protocol = LyngdorfProtocol(None, None)
+
+        def create_conn(proto_lambda, host, port):
+            proto = proto_lambda()
+            protocol._on_connection_lost = proto._on_connection_lost
+            protocol._on_message = proto._on_message
+            return [transport, proto]
+
+        client = await async_create_receiver(FAKE_IP, LyngdorfModel.TDAI_1120)
+
+        with mock.patch("asyncio.get_event_loop", new_callable=mock.Mock) as debug_mock:
+            debug_mock.return_value.create_connection = AsyncMock(
+                side_effect=create_conn
+            )
+            await client.async_connect()
+            self.future = asyncio.Future()
+            client._api.register_callback("BAL", self._callback)
+            protocol.data_received(
+                bytes("\r".join([*commands_received, "!BAL(0)"]) + "\r", "utf-8")
+            )
+            await self.future
+            test_function(client)
+            await client.async_disconnect()
+
+
+# =============================================================================
 # TDAI-2170 Fixed Lists
 #
 # TDAI-2170 has no count+enumeration burst for sources, RoomPerfect
@@ -2775,3 +2903,52 @@ class TestMessageFraming:
         assert self._collect(b'!SRCNAME(6,"A2 HT Bypass Adam")\r\n') == [
             '!SRCNAME(6,"A2 HT Bypass Adam")'
         ]
+
+
+# =============================================================================
+# Command Splitting
+#
+# Found via real TDAI-1120 hardware testing (PR #18 follow-up): a `)`
+# inside a quoted name must not be mistaken for the parameter's own
+# closing paren. !SRCNAME(0,"Digital 1 (Coax)") has one `)` that belongs
+# to the name and one that actually closes the parameter - a naive
+# str.find(")") finds the first (wrong) one, truncating the name and
+# misparsing everything after it as trailing content.
+# =============================================================================
+
+
+class TestSplitCommand:
+    """LyngdorfApi._split_command must be quote-aware."""
+
+    def test_name_containing_close_paren_is_not_truncated(self):
+        assert LyngdorfApi._split_command('SRCNAME(0,"Digital 1 (Coax)")') == (
+            "SRCNAME",
+            '0,"Digital 1 (Coax)"',
+            "",
+        )
+
+    def test_mp_style_trailing_name_with_parens_unaffected(self):
+        """MP's shape (name outside the parens) still splits correctly,
+        even when that name itself contains parens."""
+        assert LyngdorfApi._split_command('SRC(0)"Input (HDMI)"') == (
+            "SRC",
+            "0",
+            '"Input (HDMI)"',
+        )
+
+    def test_ordinary_mp_style_reply(self):
+        assert LyngdorfApi._split_command('SRC(0)"HDMI"') == (
+            "SRC",
+            "0",
+            '"HDMI"',
+        )
+
+    def test_bare_command_has_no_parameter(self):
+        assert LyngdorfApi._split_command("MUTEON") == ("MUTEON", "", "")
+
+    def test_unterminated_paren_falls_back_to_bare_command(self):
+        assert LyngdorfApi._split_command('SRCNAME(0,"Unterminated') == (
+            'SRCNAME(0,"Unterminated',
+            "",
+            "",
+        )


### PR DESCRIPTION
Both issues found by @Pharkie testing v1.4.3 against a real TDAI-1120 - see [the comment on #18](https://github.com/fishloa/lyngdorf/pull/18#issuecomment-5201774613).

## 1. Names containing `)` were truncated

\`_process_event\` took the first \`)\` in a message as its parameter's closing paren. On TDAI's comma-packed name shape:

\`\`\`
!SRCNAME(0,"Digital 1 (Coax)")
         ^ param starts   ^ first ) - belongs to the name, not the parameter
\`\`\`

...that first \`)\` belongs to the name, not the parameter. Four of Pharkie's fourteen real sources came back clipped (\`Digital 1 (Coax\`, \`Digital 2 (Coax\`, \`Digital 3 (Opt.\`). Pre-existing in the parser, just unreachable until SRCNAME started populating in #18.

**Fix:** replaced the \`find()\`-based split with \`LyngdorfApi._split_command\`, which tracks quote state and only treats a \`)\` outside quotes as the real terminator.

MP's shape (name trailing, *outside* the parens - \`!SRC(0)"Name"\`) was never actually at risk, since its parameter always closes before any name begins - confirmed by a dedicated test (\`test_mp_style_trailing_name_with_parens_unaffected\`) and against a real MP-60.

## 2. RPNAME/VOINAME have the exact gap SRCNAME had before #18

\`!RP?\`/\`!VOI?\` on TDAI-1120/3400 reply with a bare index and no name - the name-bearing replies are keyed under \`RPNAME\`/\`VOINAME\` instead, same comma-packed shape as \`SRCNAME\`:

\`\`\`
!RPLIST?  -> !RPCOUNT(3) + !RPNAME(0,"Bypass") + !RPNAME(1,"Focus") + !RPNAME(9,"Global")
!VOILIST? -> !VOICOUNT(14) + !VOINAME(0,"Neutral") + ... + !VOINAME(13,"Bass 2")
\`\`\`

\`room_perfect_position\` and \`voicing\` stayed \`None\` on a TDAI-1120/3400 as a result. Non-contiguous indices (Pharkie's amp: RPNAME 0/1/9, sources 0-6/8-11/25-27) aren't an issue - the count-based population already handles arbitrary integer keys.

**Fix:** mirrors #18 exactly - new \`Msg.ROOM_PERFECT_POSITION_NAME\`/\`ROOM_PERFECT_VOICING_NAME\` mapped to \`RPNAME\`/\`VOINAME\`, two dedicated callbacks that split the comma-packed reply, and \`async_connect()\` picks whichever message a model actually has. TDAI-2170 keeps its own fixed-list mechanism from #19; MP/P take the unchanged path.

**No public API changes.**

## Verification

- 186 tests pass, \`black\`/\`ruff\`/\`mypy\` clean.
- New \`TestSplitCommand\`: the exact truncation case, MP's shape with parens in the name, ordinary cases, bare commands, unterminated parens.
- New \`TestTdaiRoomPerfectAndVoicingName\`: list-population and current-value resolution for both RP positions and voicings, mirroring \`TestTdaiSourceName\`.
- Confirmed against a real MP-60 that \`source\`/\`room_perfect_position\`/\`voicing\` and their \`available_*\` lists are unaffected.

The parser fix is directly confirmed by Pharkie's report. The RPNAME/VOINAME fix is spec-derived from \`docs/tdai-1120.md\` and not yet verified against real hardware, but Pharkie - if you're willing, this would be a good one to check on your 1120 too.