### PR TITLE
Fix TDAI keep-alive using unsupported PING, causing periodic forced reconnects

### DIFF
--- a/lyngdorf/api.py
+++ b/lyngdorf/api.py
@@ -206,17 +206,13 @@ class LyngdorfApi:
             return
 
         if time_since_response > MONITOR_INTERVAL and self._protocol:
-            # Keep the connection alive
-            try:
-                ping_command = self._model.lookup_command(Msg.PING)
-            except KeyError:
-                _LOGGER.debug(
-                    "%s: model %s has no PING command; skipping keep-alive",
-                    self.host,
-                    self._model,
-                )
-            else:
-                self._writeCommand(f"{ping_command}?")
+            # Keep the connection alive. Which message to query is a
+            # per-model choice (ModelConfig.keepalive_message) - the API
+            # itself is generic and doesn't assume any particular command
+            # is universally supported.
+            if keepalive_message := self._model.keepalive_message:
+                keepalive_command = self._model.lookup_command(keepalive_message)
+                self._writeCommand(f"{keepalive_command}?")
         self._schedule_monitor()
 
     def _handle_disconnected(self) -> None:

--- a/lyngdorf/device.py
+++ b/lyngdorf/device.py
@@ -294,7 +294,12 @@ class Receiver:
     # Basics
 
     def _name_callback(self, param1: str, param2: str) -> None:
-        self._name = param1
+        # DEVICE is also the keep-alive probe (ModelConfig.keepalive_message),
+        # so this fires every MONITOR_INTERVAL on an idle connection with an
+        # unchanged reply - skip the reassignment rather than redo it on
+        # every poll for no reason.
+        if param1 != self._name:
+            self._name = param1
 
     @property
     def name(self):

--- a/lyngdorf/models/__init__.py
+++ b/lyngdorf/models/__init__.py
@@ -22,6 +22,7 @@ Usage:
 
 from enum import Enum
 
+from ..const import Msg
 from .base import ModelCapability, ModelConfig
 from .mp_series import MP40_CONFIG, MP50_CONFIG, MP60_CONFIG
 from .p_series import P100_CONFIG, P200_CONFIG, P300_CONFIG
@@ -143,6 +144,16 @@ class LyngdorfModel(Enum):
         """
         return self.value.mute_state_in_parameter
 
+    @property
+    def keepalive_message(self) -> Msg | None:
+        """Message type this model uses for connection keep-alive/probing.
+
+        Returns:
+            The Msg to query to keep the connection alive, or None if this
+            model has no keep-alive query
+        """
+        return self.value.keepalive_message
+
     def supports_message(self, key) -> bool:
         """Check whether this model's protocol defines a given message.
 
@@ -165,8 +176,6 @@ class LyngdorfModel(Enum):
         Returns:
             dict[Msg, bool] covering every Msg enum member
         """
-        from ..const import Msg
-
         return {msg: msg in self.value.messages for msg in Msg}
 
 

--- a/lyngdorf/models/base.py
+++ b/lyngdorf/models/base.py
@@ -85,6 +85,14 @@ class ModelConfig:
             on the MUTE message (`!MUTE(ON)` / `!MUTE(OFF)`, the TDAI
             family) rather than as distinct `!MUTEON` / `!MUTEOFF`
             messages (the MP and P families).
+        keepalive_message: Message type queried to keep an idle connection
+            alive and to detect a dead one (`LyngdorfApi._monitor`). Must be
+            a message every model in `messages` actually defines - DEVICE
+            is the one truly universal query across every model, including
+            TDAI-2170's more limited protocol subset, which doesn't even
+            have VERBOSE. None disables the keep-alive query entirely (the
+            connection is still torn down and reconnected on prolonged
+            silence, just without an active probe first).
     """
 
     model_name: str
@@ -103,6 +111,7 @@ class ModelConfig:
     has_surround: bool = False
     power_state_on: str = POWER_ON
     mute_state_in_parameter: bool = False
+    keepalive_message: Msg | None = Msg.DEVICE
 
     def lookup_command(self, key: Msg) -> str:
         """Lookup protocol command for a given message type.

--- a/tests/basic_wiring_test.py
+++ b/tests/basic_wiring_test.py
@@ -2394,9 +2394,9 @@ class TestKeepaliveIsGenericAndUniversal:
         for model in supported_models():
             keepalive = model.keepalive_message
             assert keepalive is not None, f"{model} has no keepalive_message"
-            assert model.supports_message(keepalive), (
-                f"{model} keepalive_message {keepalive} is not in its own messages"
-            )
+            assert model.supports_message(
+                keepalive
+            ), f"{model} keepalive_message {keepalive} is not in its own messages"
 
     @pytest.mark.asyncio
     async def test_monitor_sends_keepalive_for_tdai_model(self):

--- a/tests/basic_wiring_test.py
+++ b/tests/basic_wiring_test.py
@@ -1,11 +1,13 @@
 import asyncio
 import logging
+import time
 from unittest import mock
 
 import pytest
 
 from lyngdorf.api import LyngdorfApi, LyngdorfProtocol
 from lyngdorf.const import (
+    MONITOR_INTERVAL,
     MP40_AUDIO_INPUTS,
     MP40_STREAM_TYPES,
     MP40_VIDEO_INPUTS,
@@ -2367,6 +2369,75 @@ class TestPongDetectionDefensive:
 
         api._process_event("!DEVICE(TDAI-3400)")  # must not raise
         await asyncio.sleep(0)  # let the created task run
+
+
+class TestKeepaliveIsGenericAndUniversal:
+    """Regression tests: _monitor used to look up Msg.PING for its
+    keep-alive query, which the TDAI family never defines. The staleness
+    check that force-disconnects and reconnects on prolonged silence still
+    ran regardless, so an idle-but-healthy TDAI connection - one that
+    never got an actual keep-alive sent to reset the staleness clock -
+    was torn down and reconnected every MONITOR_INTERVAL * 4 seconds
+    forever. Reported against a real TDAI-1120 as locking up the device
+    itself (unresponsive front panel, unresponsive to the official
+    Android app, requiring a mains power cycle).
+
+    ModelConfig.keepalive_message makes the choice of keep-alive command a
+    per-model config value (defaulting to DEVICE, the one query every
+    current model defines - including TDAI-2170's more limited protocol,
+    which doesn't even have VERBOSE) rather than something LyngdorfApi
+    hardcodes, so the API itself has no assumption about which command is
+    universal.
+    """
+
+    def test_every_model_has_a_keepalive_message_it_actually_supports(self):
+        for model in supported_models():
+            keepalive = model.keepalive_message
+            assert keepalive is not None, f"{model} has no keepalive_message"
+            assert model.supports_message(keepalive), (
+                f"{model} keepalive_message {keepalive} is not in its own messages"
+            )
+
+    @pytest.mark.asyncio
+    async def test_monitor_sends_keepalive_for_tdai_model(self):
+        api = LyngdorfApi(FAKE_IP, LyngdorfModel.TDAI_1120)
+        assert Msg.PING not in api._model.config.messages
+        api._protocol = mock.Mock()
+        api._last_message_time = time.monotonic() - MONITOR_INTERVAL - 1
+
+        api._monitor()
+        if api._monitor_handle is not None:
+            api._monitor_handle.cancel()
+
+        sent = [call.args[0] for call in api._protocol.write.call_args_list]
+        assert sent == ["!DEVICE?\r"]
+
+    @pytest.mark.asyncio
+    async def test_monitor_sends_keepalive_for_tdai_2170_which_has_no_verbose(self):
+        api = LyngdorfApi(FAKE_IP, LyngdorfModel.TDAI_2170)
+        assert Msg.VERBOSE not in api._model.config.messages
+        api._protocol = mock.Mock()
+        api._last_message_time = time.monotonic() - MONITOR_INTERVAL - 1
+
+        api._monitor()
+        if api._monitor_handle is not None:
+            api._monitor_handle.cancel()
+
+        sent = [call.args[0] for call in api._protocol.write.call_args_list]
+        assert sent == ["!DEVICE?\r"]
+
+    @pytest.mark.asyncio
+    async def test_monitor_sends_keepalive_for_mp_model(self):
+        api = LyngdorfApi(FAKE_IP, LyngdorfModel.MP_60)
+        api._protocol = mock.Mock()
+        api._last_message_time = time.monotonic() - MONITOR_INTERVAL - 1
+
+        api._monitor()
+        if api._monitor_handle is not None:
+            api._monitor_handle.cancel()
+
+        sent = [call.args[0] for call in api._protocol.write.call_args_list]
+        assert sent == ["!DEVICE?\r"]
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes #27.

`_monitor()` hardcoded `Msg.PING` for its keep-alive query. The TDAI family has no PING command, so the keep-alive silently no-oped while the staleness check that force-disconnects after 4x the monitor interval still ran unconditionally — any idle TDAI connection got torn down and reconnected every 6 minutes forever, replaying the full setup command burst each time.

Reported (home-assistant/core#178508) against a real TDAI-1120 as locking up the device's own control subsystem — unresponsive front panel and official Android app, requiring a mains power cycle.

## Fix

Made the keep-alive command a per-model config value (`ModelConfig.keepalive_message`) instead of hardcoded in the generic `LyngdorfApi._monitor()`. Defaults to `Msg.DEVICE` — the only query present across every model, including TDAI-2170's more limited protocol (which lacks `VERBOSE` too, so that wasn't a safe universal choice either — caught this by the new regression test before it shipped).

## Tests

- Every model's `keepalive_message` must be one of its own supported messages.
- `_monitor()` actually sends a keep-alive command for TDAI-1120, TDAI-2170, and MP-60 (mocked protocol, asserting on the written bytes).

192/192 tests pass, ruff/mypy clean.