### PR TITLE
Fix reconnect opening duplicate/orphaned connections

### DIFF
--- a/lyngdorf/api.py
+++ b/lyngdorf/api.py
@@ -175,6 +175,11 @@ class LyngdorfApi:
             raise ConnectionRefusedError(
                 f"ConnectionRefusedError: {err}", "connect"
             ) from err
+        # Never overwrite a live protocol without closing it first: a stale
+        # transport left dangling stays ESTABLISHED on the device and leaks a
+        # control-port slot (the TDAI family allows only a few connections).
+        if self._protocol is not None:
+            self._protocol.close()
         self._protocol = cast(LyngdorfProtocol, transport_protocol[1])  # type: ignore
         self._connection_enabled = True
         self._last_message_time = time.monotonic()
@@ -184,6 +189,10 @@ class LyngdorfApi:
 
     def _schedule_monitor(self) -> None:
         """Start the monitor task."""
+        # Cancel any monitor already scheduled: every (re)connect calls this,
+        # and without cancelling, monitors accumulate and each independently
+        # fires its own keepalive-timeout disconnect/reconnect.
+        self._stop_monitor()
         loop = asyncio.get_event_loop()
         self._monitor_handle = loop.call_later(MONITOR_INTERVAL, self._monitor)
 
@@ -222,6 +231,12 @@ class LyngdorfApi:
         self._stop_monitor()
         if not self._connection_enabled:
             return
+        # Only ever run one reconnect loop. This handler can fire more than
+        # once for a single drop (eof_received + connection_lost, and the
+        # monitor's close() + explicit call); spawning a task each time opens
+        # duplicate connections and orphans sockets on the device.
+        if self._reconnect_task is not None and not self._reconnect_task.done():
+            return
         self._reconnect_task = asyncio.create_task(self._async_reconnect())
 
     async def async_disconnect(self) -> None:
@@ -243,6 +258,11 @@ class LyngdorfApi:
         while self._connection_enabled and not self.healthy:
             _LOGGER.debug("Trying to reconnect...")
             async with self._connect_lock:
+                # Another attempt may have connected while we waited for the
+                # lock; re-check under it so we don't establish (and leak) a
+                # second connection.
+                if self.healthy:
+                    return
                 try:
                     await self._async_establish_connection()
                 except Exception:  # pylint: disable=broad-except

--- a/tests/reconnect_leak_test.py
+++ b/tests/reconnect_leak_test.py
@@ -1,0 +1,97 @@
+"""Regression test for the reconnect connection-leak.
+
+Before the fix, a single device-initiated disconnect double-fired the
+reconnect path (``eof_received`` calls both ``close()`` and
+``on_connection_lost``) and raced through the ``self.healthy`` guard in
+``_async_reconnect`` (checked before the connect lock was held), so two
+connections were opened and one was left **orphaned** - still ESTABLISHED on
+the device. On a device with a small connection table (e.g. a TDAI-3400,
+control port 84) these accumulate until it refuses all clients.
+
+This test stands a fake asyncio server in for the device and asserts that N
+device-initiated drops leave exactly one live connection and open no more
+than N+1 in total.
+"""
+import asyncio
+
+import pytest
+
+from lyngdorf import api as lyngdorf_api
+from lyngdorf.api import LyngdorfApi
+from lyngdorf.const import LyngdorfModel
+
+
+class _FakeAmp(asyncio.Protocol):
+    """Counts connections received and how many are still open."""
+
+    total = 0
+    live = 0
+
+    def connection_made(self, transport):
+        type(self).total += 1
+        type(self).live += 1
+
+    def connection_lost(self, exc):
+        type(self).live -= 1
+
+    def data_received(self, data):
+        # Swallow the client's setup-command burst. A real device replies,
+        # but the reconnect logic under test doesn't depend on replies.
+        pass
+
+
+async def _wait_healthy(api, timeout=2.0):
+    elapsed = 0.0
+    while not api.healthy and elapsed < timeout:
+        await asyncio.sleep(0.02)
+        elapsed += 0.02
+    assert api.healthy, "client never became healthy"
+
+
+@pytest.mark.asyncio
+async def test_reconnect_does_not_leak_connections(monkeypatch):
+    _FakeAmp.total = 0
+    _FakeAmp.live = 0
+
+    loop = asyncio.get_running_loop()
+    server = await loop.create_server(_FakeAmp, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    monkeypatch.setattr(lyngdorf_api, "DEFAULT_LYNGDORF_PORT", port)
+
+    api = LyngdorfApi("127.0.0.1", LyngdorfModel.TDAI_3400)
+    try:
+        await api.async_connect()
+        await _wait_healthy(api)
+        assert _FakeAmp.live == 1
+
+        n_drops = 3
+        for _ in range(n_drops):
+            # Simulate the device dropping the link (FIN -> client eof_received)
+            assert api._protocol is not None
+            api._protocol.eof_received()
+            await _wait_healthy(api)
+
+        # Let any stray reconnect tasks / server-side closes settle.
+        await asyncio.sleep(0.3)
+
+        assert api.healthy
+        assert _FakeAmp.live == 1, (
+            f"orphaned/leaked connections left open on device: "
+            f"{_FakeAmp.live - 1}"
+        )
+        assert _FakeAmp.total <= n_drops + 1, (
+            f"opened too many connections: {_FakeAmp.total} "
+            f"(expected <= {n_drops + 1})"
+        )
+    finally:
+        await api.async_disconnect()
+        server.close()
+        # A leak leaves orphaned client sockets open, which would make
+        # wait_closed() hang; drop server-side conns and bound the wait so
+        # the assertions above surface as a clean failure rather than a hang.
+        if hasattr(server, "close_clients"):
+            server.close_clients()
+        try:
+            await asyncio.wait_for(server.wait_closed(), 2.0)
+        except (asyncio.TimeoutError, TimeoutError):
+            pass


### PR DESCRIPTION
Fixes #29.

The reconnect path in `lyngdorf/api.py` could open more than one connection
per disconnect and leave sockets orphaned (ESTABLISHED on the device but
unreferenced by the client). On a TDAI-3400, whose control port `:84` accepts
only a few simultaneous connections, these accumulate until the device
accept-then-RSTs every client, recovering only on a reboot.

## Changes
- Run a single reconnect loop; make `_handle_disconnected` idempotent (it can
  fire twice per drop via `eof_received` and the monitor timeout).
- Re-check `self.healthy` inside the connect lock in `_async_reconnect` to
  close the duplicate-connection race.
- Close any existing protocol before assigning a new one in
  `_async_establish_connection`.
- Cancel the prior monitor in `_schedule_monitor`.

## Validation
- Real TDAI-3400, 3 device-initiated disconnects: before, opened 7 / leaked 3;
  after, opened 4 / leaked 0 and stayed healthy.
- Added a hermetic regression test (fake asyncio server, no hardware) that
  fails on the previous behaviour and passes with the fix.
- Full suite: 212 passed (211 existing + the new test).
